### PR TITLE
update gralloc header

### DIFF
--- a/include/hardware/gralloc.h
+++ b/include/hardware/gralloc.h
@@ -135,6 +135,9 @@ enum {
      * out by GRALLOC_USAGE_ALLOC_MASK, so gralloc modules will not need to
      * handle this flag. */
     GRALLOC_USAGE_FOREIGN_BUFFERS       = 0x00200000U,
+    
+    /* buffer will be used as input to HW HEIC image encoder */
+    GRALLOC_USAGE_HW_IMAGE_ENCODER      = 0x08000000U,
 
     /* Mask of all flags which could be passed to a gralloc module for buffer
      * allocation. Any flags not in this mask do not need to be handled by


### PR DESCRIPTION
Fixes error
frameworks/av/services/camera/libcameraservice/api2/HeicCompositeStream.cpp:328:53: error: use of undeclared identifier 'GRALLOC_USAGE_HW_IMAGE_ENCODER'; did you mean 'GRALLOC_USAGE_HW_VIDEO_ENCODER'?
    (*compositeOutput)[1].consumerUsage = useHeic ? GRALLOC_USAGE_HW_IMAGE_ENCODER :