### PR TITLE
universal7870:  add missing vendor blobs with dependencys and silence…

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -39,6 +39,9 @@ vendor/lib/hw/camera.exynos5.so
 vendor/lib64/hw/camera.universal7870.so
 vendor/lib/libcamera_client.so
 vendor/lib/libgui.so
+vendor/lib/libacryl.so
+vendor/lib/libuniapi.so
+vendor/lib64/libuniapi.so
 
 # DRM
 vendor/lib/liboemcrypto.so


### PR DESCRIPTION
… major vndk definition warnings by kanging them from a7y18lte:10/QP1A.190711.020/A750FNXXU5CTK1; hexedit lib64 com.qualcomm.qti.ant@1.0-impl.so to load android.hardware.bluetooth@1.0-impl.so instad of android.hardware.bluetooth@1.0-impl-qti.so [2/2]:

Signed-off-by: imannig <zahranansaria@gmail.com>